### PR TITLE
Patch to make Pico-Green-Colck compile under Windows using VS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+.vscode/
+.git
+htmldata.c
+pico_sdk_import.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ pico_add_extra_outputs(Pico-Green-Clock)
 #
 #
 # Pull in our pico_stdlib which pulls in commonly used features
-target_link_libraries(Pico-Green-Clock hardware_adc hardware_flash hardware_i2c hardware_pwm hardware_sync pico_stdlib pico_unique_id pico_multicore pico_cyw43_arch_lwip_threadsafe_background pico_lwip_http pico_cyw43_arch)
+target_link_libraries(Pico-Green-Clock hardware_adc hardware_flash hardware_i2c hardware_pwm hardware_sync pico_stdlib pico_unique_id pico_multicore pico_cyw43_arch_lwip_threadsafe_background pico_lwip_http)
 #
 #
 # add url via pico_set_program_url

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,19 @@
+# == DO NEVER EDIT THE NEXT LINES for Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.0.0)
+set(toolchainVersion 13_2_Rel1)
+set(picotoolVersion 2.0.0)
+include(${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+# ====================================================================================
 # CMakeLists.txt
 # For Pico-Green-Clock
 # CMakeLists.txt version for Pico W, with NTP support.
 #
+set (PICO_BOARD pico_w)
 #
 cmake_minimum_required(VERSION 3.13)
 #
@@ -15,7 +27,6 @@ project(Pico-Green-Clock)
 # set (CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 set (C_STANDARD 11)
 set (CXX_STANDARD 17)
-set (PICO_BOARD pico_w)
 #
 #
 pico_sdk_init()
@@ -39,6 +50,7 @@ add_executable(Pico-Green-Clock
 target_include_directories(Pico-Green-Clock PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/.. # for our common lwipopts
+        ${PICO_SDK_PATH}/src/rp2_common/pico_cyw43_arch/include # for the WiFi hardware
         )
 #
 #
@@ -52,7 +64,7 @@ pico_add_extra_outputs(Pico-Green-Clock)
 #
 #
 # Pull in our pico_stdlib which pulls in commonly used features
-target_link_libraries(Pico-Green-Clock hardware_adc hardware_flash hardware_i2c hardware_pwm hardware_sync pico_stdlib pico_unique_id pico_multicore pico_cyw43_arch_lwip_threadsafe_background pico_lwip_http)
+target_link_libraries(Pico-Green-Clock hardware_adc hardware_flash hardware_i2c hardware_pwm hardware_sync pico_stdlib pico_unique_id pico_multicore pico_cyw43_arch_lwip_threadsafe_background pico_lwip_http pico_cyw43_arch)
 #
 #
 # add url via pico_set_program_url


### PR DESCRIPTION
What I've changend and why:
added ``.gitignore`` file (for a clean commit to github)

in ``CMakeLists.txt``:
line 1 - 11 was added by VS plugin. Does not hurt, but you can remove it.
moved ``set (PICO_BOARD pico_w)`` to the top, which is needed by the VS plugin
line 53 adds the path to the ``pico_cyw43_arch/include`` directory. Ths is the fixes my compile error. 

If you want you can add the instructions how to compile under windows using VS (assuming everything is installed as described in the guide from Raspberry Pi:

- clone the repository
- import project with the raspberry pico plugin
- compile (again with the plugin

that's all folks!